### PR TITLE
URL encode comma (,) in uri

### DIFF
--- a/src/aws_sig4/auth.clj
+++ b/src/aws_sig4/auth.clj
@@ -36,7 +36,8 @@
     "/"
     (let [^String normalized (-> uri
                                  pathetic/normalize
-                                 (str/replace #"\*" "%2A"))]
+                                 (str/replace #"\*" "%2A")
+                                 (str/replace #"," "%2C"))]
       (if (and (> (.length normalized) 1)
                (= (.charAt uri (- (.length uri) 1)) \/))
         (str normalized "/")


### PR DESCRIPTION
This fixes #4, so one can use urls containing a comma like in elastic search index pattern for excluding indices for example `/*,-notme/_search`.