### PR TITLE
Encode semicolon in canonical request

### DIFF
--- a/src/aws_sig4/auth.clj
+++ b/src/aws_sig4/auth.clj
@@ -37,7 +37,8 @@
     (let [^String normalized (-> uri
                                  pathetic/normalize
                                  (str/replace #"\*" "%2A")
-                                 (str/replace #"," "%2C"))]
+                                 (str/replace #"," "%2C")
+                                 (str/replace #":" "%3A"))]
       (if (and (> (.length normalized) 1)
                (= (.charAt uri (- (.length uri) 1)) \/))
         (str normalized "/")


### PR DESCRIPTION
This allows bedrock service to work, since model id's might have semicolons, e.g. /model/amazon.titan-embed-text-v2:0/invoke